### PR TITLE
Update vhost.sh

### DIFF
--- a/vhost.sh
+++ b/vhost.sh
@@ -1050,8 +1050,30 @@ EOF
   Print_SSL
 }
 
+
+Prompt_Proxy_Mode() {
+  while :; do echo
+    echo "Please choose site mode:"
+    echo -e "	${CMSG}1${CEND}. Website Mode (default)"
+    echo -e "	${CMSG}2${CEND}. Reverse Proxy Mode"
+    read -e -p "Please input a number:(Default 1 press Enter) " PROXY_MODE_OPT
+    PROXY_MODE_OPT=${PROXY_MODE_OPT:-1}
+    if [[ ! ${PROXY_MODE_OPT} =~ ^[1-2]$ ]]; then
+      echo "${CWARNING}input error! Please only input number 1~2${CEND}"
+    else
+      break
+    fi
+  done
+  [ "${PROXY_MODE_OPT}" == '2' ] && proxy_flag='y'
+}
+
 Add_Vhost() {
-  if [ -e "${web_install_dir}/sbin/nginx" -a ! -e "${apache_install_dir}/bin/httpd" ]; then
+  
+  # --- Interactive: Website vs Proxy ---
+  if [ "${ARG_NUM}" = "0" ] && [[ -z ${proxy_flag} || "${proxy_flag}" != 'y' ]]; then
+    Prompt_Proxy_Mode
+  fi
+if [ -e "${web_install_dir}/sbin/nginx" -a ! -e "${apache_install_dir}/bin/httpd" ]; then
     Choose_ENV
     Input_Add_domain
     Nginx_anti_hotlinking

--- a/vhost.sh
+++ b/vhost.sh
@@ -497,9 +497,9 @@ What Are You Doing?
 
     Create_SSL
     if [ -n "`ifconfig | grep inet6`" ]; then
-      Nginx_conf=$(echo -e "listen 80;\n  listen [::]:80;\n  listen 443 ssl;\n  listen [::]:443 ssl;\n  ssl_certificate ${PATH_SSL}/${domain}.crt;\n  ssl_certificate_key ${PATH_SSL}/${domain}.key;\n  ssl_protocols TLSv1.2 TLSv1.3;\n  ssl_ecdh_curve X25519:prime256v1:secp384r1:secp521r1;\n  ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256;\n  ssl_conf_command Ciphersuites TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256;\n  ssl_conf_command Options PrioritizeChaCha;\n  ssl_prefer_server_ciphers on;\n  ssl_session_timeout 10m;\n  ssl_session_cache shared:SSL:10m;\n  ssl_buffer_size 2k;\n  add_header Strict-Transport-Security max-age=15768000;\n  ssl_stapling on;\n  ssl_stapling_verify on;\n")
+      Nginx_conf=$(echo -e "listen 80;\n  listen [::]:80;\n  listen 443 ssl http2;\n  listen [::]:443 ssl http2;\n  ssl_certificate ${PATH_SSL}/${domain}.crt;\n  ssl_certificate_key ${PATH_SSL}/${domain}.key;\n  ssl_trusted_certificate ${PATH_SSL}/${domain}.crt;\n  ssl_protocols TLSv1.2 TLSv1.3;\n  ssl_ciphers ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256;\n  ssl_conf_command Ciphersuites TLS_CHACHA20_POLY1305_SHA256:TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256;\n  ssl_prefer_server_ciphers off;\n  ssl_ecdh_curve X25519:secp384r1:secp256r1;\n  ssl_session_cache shared:SSL:10m;\n  ssl_session_timeout 1d;\n  ssl_session_tickets off;\n  add_header Strict-Transport-Security \"max-age=15768000\" always;\n  ssl_stapling on;\n  ssl_stapling_verify on;\n  resolver 1.1.1.1 8.8.8.8 valid=300s;\n  resolver_timeout 5s;\n")
     else
-      Nginx_conf=$(echo -e "listen 80;\n  listen 443 ssl;\n  ssl_certificate ${PATH_SSL}/${domain}.crt;\n  ssl_certificate_key ${PATH_SSL}/${domain}.key;\n  ssl_protocols TLSv1.2 TLSv1.3;\n  ssl_ecdh_curve X25519:prime256v1:secp384r1:secp521r1;\n  ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256;\n  ssl_conf_command Ciphersuites TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256;\n  ssl_conf_command Options PrioritizeChaCha;\n  ssl_prefer_server_ciphers on;\n  ssl_session_timeout 10m;\n  ssl_session_cache shared:SSL:10m;\n  ssl_buffer_size 2k;\n  add_header Strict-Transport-Security max-age=15768000;\n  ssl_stapling on;\n  ssl_stapling_verify on;\n")
+      Nginx_conf=$(echo -e "listen 80;\n  listen 443 ssl http2;\n  ssl_certificate ${PATH_SSL}/${domain}.crt;\n  ssl_certificate_key ${PATH_SSL}/${domain}.key;\n  ssl_trusted_certificate ${PATH_SSL}/${domain}.crt;\n  ssl_protocols TLSv1.2 TLSv1.3;\n  ssl_ciphers ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256;\n  ssl_conf_command Ciphersuites TLS_CHACHA20_POLY1305_SHA256:TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256;\n  ssl_prefer_server_ciphers off;\n  ssl_ecdh_curve X25519:secp384r1:secp256r1;\n  ssl_session_cache shared:SSL:10m;\n  ssl_session_timeout 1d;\n  ssl_session_tickets off;\n  add_header Strict-Transport-Security \"max-age=15768000\" always;\n  ssl_stapling on;\n  ssl_stapling_verify on;\n  resolver 1.1.1.1 8.8.8.8 valid=300s;\n  resolver_timeout 5s;\n")
     fi
     Apache_SSL=$(echo -e "SSLEngine on\n  SSLCertificateFile \"${PATH_SSL}/${domain}.crt\"\n  SSLCertificateKeyFile \"${PATH_SSL}/${domain}.key\"")
   elif [ "${apache_ssl_flag}" == 'y' ]; then
@@ -741,18 +741,18 @@ EOF
     [ "${redirect_flag}" == 'y' ] && sed -i "s@^  root.*;@&\n  if (\$host != ${domain}) {  return 301 \$scheme://${domain}\$request_uri;  }@" ${web_install_dir}/conf/vhost/${domain}.conf
 
     if [ "${nginx_ssl_flag}" == 'y' ]; then
-      sed -i "s@^  listen 80;@&\n  listen 443 ssl;@" ${web_install_dir}/conf/vhost/${domain}.conf
+      sed -i "s@^  listen 80;@&\n  listen 443 ssl http2;@" ${web_install_dir}/conf/vhost/${domain}.conf
       sed -i "s@^  server_name.*;@&\n  ssl_stapling_verify on;@" ${web_install_dir}/conf/vhost/${domain}.conf
       sed -i "s@^  server_name.*;@&\n  ssl_stapling on;@" ${web_install_dir}/conf/vhost/${domain}.conf
       sed -i "s@^  server_name.*;@&\n  add_header Strict-Transport-Security max-age=15768000;@" ${web_install_dir}/conf/vhost/${domain}.conf
-      sed -i "s@^  server_name.*;@&\n  ssl_buffer_size 2k;@" ${web_install_dir}/conf/vhost/${domain}.conf
+      sed -i "s@^  server_name.*;@&@" ${web_install_dir}/conf/vhost/${domain}.conf
       sed -i "s@^  server_name.*;@&\n  ssl_session_cache shared:SSL:10m;@" ${web_install_dir}/conf/vhost/${domain}.conf
-      sed -i "s@^  server_name.*;@&\n  ssl_session_timeout 10m;@" ${web_install_dir}/conf/vhost/${domain}.conf
-      sed -i "s@^  server_name.*;@&\n  ssl_prefer_server_ciphers on;@" ${web_install_dir}/conf/vhost/${domain}.conf
+      sed -i "s@^  server_name.*;@&\n  ssl_session_timeout 1d;@" ${web_install_dir}/conf/vhost/${domain}.conf
+      sed -i "s@^  server_name.*;@&\n  ssl_prefer_server_ciphers off;@" ${web_install_dir}/conf/vhost/${domain}.conf
       sed -i "s@^  server_name.*;@&\n  ssl_conf_command Options PrioritizeChaCha;@" ${web_install_dir}/conf/vhost/${domain}.conf
       sed -i "s@^  server_name.*;@&\n  ssl_conf_command Ciphersuites TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256;@" ${web_install_dir}/conf/vhost/${domain}.conf
-      sed -i "s@^  server_name.*;@&\n  ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256;@" ${web_install_dir}/conf/vhost/${domain}.conf
-      sed -i "s@^  server_name.*;@&\n  ssl_ecdh_curve X25519:prime256v1:secp384r1:secp521r1;@" ${web_install_dir}/conf/vhost/${domain}.conf
+      sed -i "s@^  server_name.*;@&\n  ssl_ciphers ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256;@" ${web_install_dir}/conf/vhost/${domain}.conf
+      sed -i "s@^  server_name.*;@&\n  ssl_ecdh_curve X25519:secp384r1:secp256r1;@" ${web_install_dir}/conf/vhost/${domain}.conf
       sed -i "s@^  server_name.*;@&\n  ssl_protocols TLSv1.2 TLSv1.3;@" ${web_install_dir}/conf/vhost/${domain}.conf
       sed -i "s@^  server_name.*;@&\n  ssl_certificate_key ${PATH_SSL}/${domain}.key;@" ${web_install_dir}/conf/vhost/${domain}.conf
       sed -i "s@^  server_name.*;@&\n  ssl_certificate ${PATH_SSL}/${domain}.crt;@" ${web_install_dir}/conf/vhost/${domain}.conf


### PR DESCRIPTION
This pull request makes several improvements to the `vhost.sh` script, focusing on enhancing SSL configuration for Nginx and adding an interactive prompt for selecting between website and reverse proxy modes. The main changes improve security, modernize SSL settings, and make the script more user-friendly.

**SSL Configuration Improvements:**

* Updated Nginx SSL configuration to:
  - Add `http2` to SSL listen directives for better performance.
  - Add `ssl_trusted_certificate` for improved certificate validation.
  - Use a more secure and modern set of `ssl_ciphers` and `ssl_ecdh_curve` values.
  - Set `ssl_prefer_server_ciphers` to `off` and increase `ssl_session_timeout` to `1d` for better compatibility and session management.
  - Remove deprecated options like `ssl_buffer_size` and `ssl_session_tickets` is now set to `off`.
  - Add DNS resolvers for OCSP stapling and other SSL features. [[1]](diffhunk://#diff-e2dbc2187e33535df105d1ac787455f2e633ac0d90ca051901cd30fe6220fd23L500-R502) [[2]](diffhunk://#diff-e2dbc2187e33535df105d1ac787455f2e633ac0d90ca051901cd30fe6220fd23L744-R755)

**User Interaction Enhancements:**

* Added a new `Prompt_Proxy_Mode` function that interactively asks the user to choose between "Website Mode" and "Reverse Proxy Mode" when adding a new virtual host, making the script more flexible and user-friendly.

**Script Logic Updates:**

* Integrated the new proxy mode prompt into the `Add_Vhost` function, ensuring the user is prompted appropriately when no arguments are provided and the proxy flag is not set.